### PR TITLE
Remove annoying pysha dependency

### DIFF
--- a/greed/TAC/TAC_parser.py
+++ b/greed/TAC/TAC_parser.py
@@ -2,7 +2,8 @@ import itertools
 import json
 import logging
 import os
-import sha3
+
+from eth_utils import keccak
 
 from ast import literal_eval
 from collections import defaultdict
@@ -291,9 +292,8 @@ class TAC_parser:
         funcs = [e for e in abi if e['type'] == 'function']
         for f in funcs:
             f_proto = f['name'] + '(' + ",".join([i['internalType'] for i in f['inputs']]) + ')'
-            k = sha3.keccak_256()
-            k.update(f_proto.encode('utf-8'))
-            sig_to_name[f"0x{k.hexdigest()[0:8]}"] = f_proto
+            hexdigest = bytes(keccak(f_proto.encode('utf-8'))).hex()
+            sig_to_name[f"0x{hexdigest[0:8]}"] = f_proto
 
         # Set the function names
         for f in self.factory.project.function_at.values():

--- a/greed/TAC/special_ops.py
+++ b/greed/TAC/special_ops.py
@@ -1,6 +1,6 @@
 import logging
 
-import sha3
+from eth_utils import keccak
 
 from greed import options
 from greed.utils import encoding
@@ -60,7 +60,6 @@ class TAC_Sha3(TAC_Statement):
                     log.debug(f"    Cannot calculate concrete SHA3 for {new_sha.symbol.name} due to multiple SHA solutions")
                 else:
                     # Everything has only one solution, we can calculate the SHA
-                    keccak256 = sha3.keccak_256()
                     buffer_sol = bv_unsigned_value(buffer_sol).to_bytes(bv_unsigned_value(size_sol), 'big')
 
                     # Constraining the SHA3 input buffer to the solution just calculated

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(
     install_requires=[
         'ipython>=7.16.3',
         'networkx>=2.5.1',
-        'pysha3>=1.0.2',
         'pytest==7.2.1',
         'solc-select>=0.2.1',
         'sympy>=1.9',


### PR DESCRIPTION
This dependency is not compatible with newer python versions and is annoying to work around. This change removes the dependency and replaces all SHA3 with eth_utils.keccak, which is installed by the web3 dependency anyway.