### PR TITLE
Fix Inconsistent stmt_sort_key function in TAC_parser.py

### DIFF
--- a/greed/TAC/TAC_parser.py
+++ b/greed/TAC/TAC_parser.py
@@ -48,14 +48,7 @@ class TAC_parser:
         - 0x12345_0x456
         - 0x12345S0x456
         """
-        if '_' in stmt_id:
-            assert 'S' not in stmt_id
-            return int(stmt_id.split('_')[1], base=16)
-        elif 'S' in stmt_id:
-            assert '_' not in stmt_id
-            return int(stmt_id.split('0x')[1].split('S')[0], base=16)
-        else:
-            return int(stmt_id.split('0x')[1], base=16)
+        return int(stmt_id.split('0x')[1].split('_')[0].split('S')[0], base=16)
         
 
     def parse_statements(self) -> Dict[str, TAC_Statement]:


### PR DESCRIPTION
#### Problem:
The current implementation of the function in repository returns inconsistent results for different representations of the same key. This inconsistency can lead to unexpected behaviors.

#### Example:
Using the old and new implementations of the function with the following inputs:

```python
inputs = ["0x12345", "0x12345_0x456", "0x12345S0x456"]
```

**Old Implementation Output:**
```python
>>> list(map(old_implementation, inputs))
[74565, 1110, 74565]
```

**New Implementation Output:**
```python
>>> list(map(my_new_implementation, inputs))
[74565, 74565, 74565]
```

#### Expected Behavior:
All representations of the same key should return the same output to ensure consistency across all uses.