### PR TITLE
Ubuntu22.04 requires additional package

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -71,6 +71,7 @@ if [ $IS_SOUFFLE_MISSING = TRUE ]; then
   if [ $IS_UBUNTU = TRUE ]; then
     read -rsn1 -p "Or press any key to install it now (ctrl-c to abort)"
     wget https://github.com/souffle-lang/souffle/releases/download/2.4/x86_64-ubuntu-2004-souffle-2.4-Linux.deb -O /tmp/x86_64-ubuntu-2004-souffle-2.4-Linux.deb &&
+    sudo apt install mcpp libffi-dev libffi7 libncurses5-dev libsqlite3-dev -y &&    
     sudo dpkg -i /tmp/x86_64-ubuntu-2004-souffle-2.4-Linux.deb &&
     rm /tmp/x86_64-ubuntu-2004-souffle-2.4-Linux.deb || { rm -f /tmp/x86_64-ubuntu-2004-souffle-2.4-Linux.deb; echo "${bold}${red}Failed to install souffle${normal}"; exit 1; }
   else

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,7 @@ if [ ${#MISSING_APT_PACKAGES[@]} -gt 0 ]; then
   echo "${bold}${red}The following packages are missing: ${MISSING_APT_PACKAGES[*]}. Please install them before proceeding (e.g., sudo apt install ${MISSING_APT_PACKAGES[*]})${normal}"
   if [ $IS_UBUNTU = TRUE ]; then
     read -rsn1 -p "Or press any key to install them now (ctrl-c to abort)"
-    sudo apt install ${MISSING_APT_PACKAGES[*]} || { echo "${bold}${red}Failed to install missing packages${normal}"; exit 1; }
+    sudo apt update && sudo apt install ${MISSING_APT_PACKAGES[*]} || { echo "${bold}${red}Failed to install missing packages${normal}"; exit 1; }
   else
     exit 1
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -47,7 +47,7 @@ for package in gcc cmake gperf libgmp-dev; do
 done
 if [ -z $NO_GIGAHORSE ]; then
   command -v >&- mkisofs || MISSING_APT_PACKAGES+=("mkisofs")
-  for package in bison build-essential clang cmake doxygen flex g++ git libffi-dev libncurses5-dev libsqlite3-dev make mcpp python sqlite zlib1g-dev libboost-all-dev; do
+  for package in bison build-essential clang cmake doxygen flex g++ git libffi7 libffi-dev libncurses5-dev libsqlite3-dev make mcpp python sqlite zlib1g-dev libboost-all-dev; do
     dpkg -l | grep -q $package || MISSING_APT_PACKAGES+=($package)
   done
   command -v >&- souffle || IS_SOUFFLE_MISSING=TRUE
@@ -71,7 +71,6 @@ if [ $IS_SOUFFLE_MISSING = TRUE ]; then
   if [ $IS_UBUNTU = TRUE ]; then
     read -rsn1 -p "Or press any key to install it now (ctrl-c to abort)"
     wget https://github.com/souffle-lang/souffle/releases/download/2.4/x86_64-ubuntu-2004-souffle-2.4-Linux.deb -O /tmp/x86_64-ubuntu-2004-souffle-2.4-Linux.deb &&
-    sudo apt install mcpp libffi-dev libffi7 libncurses5-dev libsqlite3-dev -y &&    
     sudo dpkg -i /tmp/x86_64-ubuntu-2004-souffle-2.4-Linux.deb &&
     rm /tmp/x86_64-ubuntu-2004-souffle-2.4-Linux.deb || { rm -f /tmp/x86_64-ubuntu-2004-souffle-2.4-Linux.deb; echo "${bold}${red}Failed to install souffle${normal}"; exit 1; }
   else


### PR DESCRIPTION
This pull request concerns two points:

1. Before attempting to install dependencies through apt, it is better to perform an apt update because sometimes the state of apt is not in sync with the upstream repo; this causes the apt to behave weirdly i.e. not pursuing the installation process.
2. Added additional dependency libffi7 for Ubuntu 22.04