### PR TITLE
use bytes.fromhex to load contract bytecode

### DIFF
--- a/greed/project.py
+++ b/greed/project.py
@@ -30,8 +30,8 @@ class Project(object):
             all the GigaHorse output files.
         """
         # Load the contract code
-        with open(f"{target_dir}/contract.hex", "rb") as contract_file:
-            self.code = contract_file.read()
+        with open(f"{target_dir}/contract.hex", "r") as contract_file:
+            self.code = bytes.fromhex(contract_file.read())
 
         self.factory = Factory(project=self)
 


### PR DESCRIPTION
Hi, there is an issue when trying to load the contract bytecode. When using `rb` mode, for contract bytecode like `608060`, we get `b'608060'` instead of `b'\x60\x80\x60'`. I believe the latter is what we want, so I use `bytes.fromhex` to load the bytecode.